### PR TITLE
added support for region parameters when geocoding address string

### DIFF
--- a/android/src/main/java/com/devfd/RNGeocoder/RNGeocoderModule.java
+++ b/android/src/main/java/com/devfd/RNGeocoder/RNGeocoderModule.java
@@ -31,7 +31,7 @@ public class RNGeocoderModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void geocodeAddress(String addressName, String language, Promise promise) {
+    public void geocodeAddress(String addressName, float swLat, float swLng, float neLat, float neLng, String language, Promise promise) {
         if (geocoder == null) {
             geocoder = new Geocoder(getReactApplicationContext(), new Locale(language));
         }
@@ -42,7 +42,7 @@ public class RNGeocoderModule extends ReactContextBaseJavaModule {
         }
 
         try {
-            List<Address> addresses = geocoder.getFromLocationName(addressName, 2);
+            List<Address> addresses = geocoder.getFromLocationName(addressName, 2, swLat, swLng, neLat, neLng);
             if(addresses != null && addresses.size() > 0) {
                 promise.resolve(transform(addresses));
             } else {

--- a/src/geocoder.js
+++ b/src/geocoder.js
@@ -38,7 +38,7 @@ export default {
     });
   },
 
-  geocodeAddress(address) {
+  geocodeAddress(address, swLat, swLng, neLat, neLng) {
     if (!address) {
       return Promise.reject(new Error("Address is required"));
     }
@@ -46,8 +46,15 @@ export default {
     if (this.useGoogleOnIos && this.apiKey && Platform.OS === 'ios') {
       return GoogleApi.geocodeAddress(this.apiKey, address, this.language);
     }
+    // If any of the parameters is not set for the region, we set them all to 0
+    if (swLat == null || swLng == null || neLat == null || neLng == null){
+        swLat = 0;
+        swLng = 0;
+        neLat = 0;
+        neLng = 0;
+    }
 
-    return RNGeocoder.geocodeAddress(address, this.language).catch(err => {
+    return RNGeocoder.geocodeAddress(address, swLat, swLng, neLat, neLng, this.language).catch(err => {
       if (!this.apiKey) { throw err; }
       return GoogleApi.geocodeAddress(this.apiKey, address, this.language);
     });


### PR DESCRIPTION
I made these changes originally on the old repo:
https://github.com/devfd/react-native-geocoder
My app's code is using this old repo and I only needed iOS to work.
This part works for me, but please note that:
1/ For this repo, I have not tested the code at all, my changes worked on the old repo only for iOS
2/ I wrote the Android implementation the way I imagine it would work, hopefully it compiles

Feel free to use those changes or throw them away, I shared them in case it's useful...