### PR TITLE
Adjusted to work with react-native-web

### DIFF
--- a/src/geocoder.js
+++ b/src/geocoder.js
@@ -23,18 +23,37 @@ export default {
     this.language = language;
   },
 
+  geocodePositionGoogle(position) {
+    if (this.apiKey) {
+      return GoogleApi.geocodePosition(this.apiKey, position, this.language);
+    }
+
+    // no API key - nothing we can do. We return a Promise (and reject it) because
+    // the native modules also return a Promise.
+    return new Promise((resolve, reject) => reject());
+  },
+
   geocodePosition(position) {
     if (!position || (!position.lat && position.lat!==0) || (!position.lng && position.lng!==0)) {
       return Promise.reject(new Error("Invalid position: {lat, lng} is required"));
     }
 
     if (this.useGoogleOnIos && this.apiKey && Platform.OS === 'ios') {
-      return GoogleApi.geocodePosition(this.apiKey, position, this.language);
+      // if we're on iOS and we've been told to use Google, then use Google
+      return this.geocodePositionGoogle(position);
     }
 
+    if (typeof RNGeocoder === 'undefined') {
+      // if the RNGeocoder object is *not* defined, then try to use Google.
+      // This happens if we're using this module with react-native-web, for example.
+      return this.geocodePositionGoogle(position);
+    }
+
+    // finally, try to use the Native Geocoder object for this particular platform,
+    // with a fallback to Google in case it fails.
     return RNGeocoder.geocodePosition(position, this.language).catch(err => {
       if (!this.apiKey) { throw err; }
-      return GoogleApi.geocodePosition(this.apiKey, position, this.language);
+      return this.geocodePositionGoogle(position);
     });
   },
 
@@ -44,12 +63,32 @@ export default {
     }
 
     if (this.useGoogleOnIos && this.apiKey && Platform.OS === 'ios') {
+      // if we're on iOS and we've been told to use Google, then use Google
+      return this.geocodeAddressGoogle(address);
+    }
+
+    if (typeof RNGeocoder === 'undefined') {
+      // if the RNGeocoder object is *not* defined, then try to use Google.
+      // This happens if we're using this module with react-native-web, for example.
+      return this.geocodeAddressGoogle(address);
+    }
+
+    // finally, try to use the Native Geocoder object for this particular platform,
+    // with a fallback to Google in case it fails.
+    return RNGeocoder.geocodeAddress(address, this.language).catch(err => {
+      if (!this.apiKey) { throw err; }
+      return this.geocodeAddressGoogle(address);
+    });
+  },
+
+
+  geocodeAddressGoogle(address) {
+    if (this.apiKey) {
       return GoogleApi.geocodeAddress(this.apiKey, address, this.language);
     }
 
-    return RNGeocoder.geocodeAddress(address, this.language).catch(err => {
-      if (!this.apiKey) { throw err; }
-      return GoogleApi.geocodeAddress(this.apiKey, address, this.language);
-    });
-  },
+    // no API key - nothing we can do. We return a Promise (and reject it) because
+    // the native modules also return a Promise.
+    return new Promise((resolve, reject) => reject());
+  }
 }

--- a/src/geocoder.js
+++ b/src/geocoder.js
@@ -30,7 +30,7 @@ export default {
 
     // no API key - nothing we can do. We return a Promise (and reject it) because
     // the native modules also return a Promise.
-    return new Promise.reject();
+    return Promise.reject();
   },
 
   geocodePosition(position) {
@@ -89,6 +89,6 @@ export default {
 
     // no API key - nothing we can do. We return a Promise (and reject it) because
     // the native modules also return a Promise.
-    return new Promise.reject();
+    return Promise.reject();
   }
 }

--- a/src/geocoder.js
+++ b/src/geocoder.js
@@ -30,7 +30,7 @@ export default {
 
     // no API key - nothing we can do. We return a Promise (and reject it) because
     // the native modules also return a Promise.
-    return new Promise((resolve, reject) => reject());
+    return new Promise.reject();
   },
 
   geocodePosition(position) {
@@ -89,6 +89,6 @@ export default {
 
     // no API key - nothing we can do. We return a Promise (and reject it) because
     // the native modules also return a Promise.
-    return new Promise((resolve, reject) => reject());
+    return new Promise.reject();
   }
 }


### PR DESCRIPTION
We check if RNGeocoder is defined, and only use it if it exists. If it doesn't exist, which is the case if you use this module with react-native-web, then it falls back to using the Google APIs if you have provided an API key, or it fails gracefully.