### PR TITLE
fix: added promise resolution for geocodePositionAndroid

### DIFF
--- a/android/src/main/java/com/timwangdev/reactnativegeocoder/GeocoderModule.kt
+++ b/android/src/main/java/com/timwangdev/reactnativegeocoder/GeocoderModule.kt
@@ -64,7 +64,11 @@ class GeocoderModule(reactContext: ReactApplicationContext) : ReactContextBaseJa
     if (maxResults <= 0) maxResults = 5;
     try {
       val addresses = geocoder.getFromLocation(position.getDouble("lat"), position.getDouble("lng"), maxResults)
-
+      if (addresses != null && addresses.size > 0) {
+        promise.resolve(transform(addresses))
+      } else {
+        promise.reject("EMPTY_RESULT", "Geocoder returned an empty list.")
+      }
     } catch (e: Exception) {
       promise.reject("NATIVE_ERROR", e)
     }


### PR DESCRIPTION
It seems that during a refactor the android implementation of geocodePosition lost the snippet to resolve its promise. This is [the commit](https://github.com/isaac-computer/react-native-geocoder-reborn/commit/2278a4a5df2a263dbe88a1fa210ecb134304c88c) where it got dropped