### PR TITLE
Pass options to google geocoder

### DIFF
--- a/src/geocoder.ts
+++ b/src/geocoder.ts
@@ -58,12 +58,12 @@ async function geocodePosition(
   }
 
   if (options.forceGoogleOnIos && Platform.OS === 'ios') {
-    return geocodePositionGoogle(position);
+    return geocodePositionGoogle(position, options);
   }
 
   if (nativeImpl == null) {
     if (options.fallbackToGoogle) {
-      return geocodePositionGoogle(position);
+      return geocodePositionGoogle(position, options);
     }
     throw new Error(
       'Missing Native Module: Please check the module linking, ' +
@@ -98,7 +98,7 @@ async function geocodeAddress(
   }
 
   if (options.forceGoogleOnIos && Platform.OS === 'ios') {
-    return geocodeAddressGoogle(address);
+    return geocodeAddressGoogle(address, options);
   }
 
   if (nativeImpl == null) {


### PR DESCRIPTION
The `forceGoogleOnIos` option currently is broken in `1.0.0-alpha.5` because the options object isn't being passed to the function. Currently it fails with this error:
> Invalid API Key: `apiKey` is required for using Google Maps API. 

This PR simply passes the options object to the google geocode function so it has access to the API key.